### PR TITLE
Add CodeByCommit method that returns code information grouped by commit.

### DIFF
--- a/e2etests/code/base.go
+++ b/e2etests/code/base.go
@@ -1,7 +1,6 @@
 package e2etests
 
 import (
-	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -23,8 +22,8 @@ func NewTest(t *testing.T, repoName string) *Test {
 	return s
 }
 
-func (s *Test) Run(optsp *ripsrc.Opts) []ripsrc.BlameResult {
-	t := s.t
+// cb callback to defer dirs.Remove()
+func (s *Test) Run(optsp *ripsrc.Opts, cb func(*ripsrc.Ripsrc)) {
 	dirs := testutil.UnzipTestRepo(s.repoName)
 	defer dirs.Remove()
 
@@ -33,11 +32,7 @@ func (s *Test) Run(optsp *ripsrc.Opts) []ripsrc.BlameResult {
 		opts = *optsp
 	}
 	opts.RepoDir = dirs.RepoDir
-	res, err := ripsrc.New(opts).CodeSlice(context.Background())
-	if err != nil {
-		t.Fatal("Rip returned error", err)
-	}
-	return res
+	cb(ripsrc.New(opts))
 }
 
 func assertResult(t *testing.T, want, got []ripsrc.BlameResult) {

--- a/e2etests/code/deleted_files_test.go
+++ b/e2etests/code/deleted_files_test.go
@@ -1,6 +1,7 @@
 package e2etests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pinpt/ripsrc/ripsrc"
@@ -8,7 +9,15 @@ import (
 
 func TestDeletedFiles(t *testing.T) {
 	test := NewTest(t, "deleted_files")
-	got := test.Run(nil)
+
+	var got []ripsrc.BlameResult
+	test.Run(nil, func(rip *ripsrc.Ripsrc) {
+		var err error
+		got, err = rip.CodeSlice(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	u1n := "User1"
 	u1e := "user1@example.com"

--- a/e2etests/code/editing_former_bin_file_test.go
+++ b/e2etests/code/editing_former_bin_file_test.go
@@ -1,6 +1,7 @@
 package e2etests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pinpt/ripsrc/ripsrc"
@@ -10,7 +11,15 @@ import (
 // If the file in repo was a binary at some point and then switched to text and was modified, then git log with patches does not contain the full file content. There are 2 options to fix this, either we ignore all files that at some point in history were binary or retrieve the full file content for these cases separately without using log and patches.
 func TestEditingFormerBinFile(t *testing.T) {
 	test := NewTest(t, "editing_former_bin_file")
-	got := test.Run(nil)
+
+	var got []ripsrc.BlameResult
+	test.Run(nil, func(rip *ripsrc.Ripsrc) {
+		var err error
+		got, err = rip.CodeSlice(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	u1n := "User1"
 	u1e := "user1@example.com"

--- a/e2etests/code/merge_basic_test.go
+++ b/e2etests/code/merge_basic_test.go
@@ -1,6 +1,7 @@
 package e2etests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pinpt/ripsrc/ripsrc"
@@ -8,7 +9,15 @@ import (
 
 func TestMergeBasic(t *testing.T) {
 	test := NewTest(t, "merge_basic")
-	got := test.Run(nil)
+
+	var got []ripsrc.BlameResult
+	test.Run(nil, func(rip *ripsrc.Ripsrc) {
+		var err error
+		got, err = rip.CodeSlice(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	u1n := "User1"
 	u1e := "user1@example.com"

--- a/e2etests/code/mutiple_branches_test.go
+++ b/e2etests/code/mutiple_branches_test.go
@@ -1,6 +1,7 @@
 package e2etests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pinpt/ripsrc/ripsrc"
@@ -9,7 +10,15 @@ import (
 
 func TestMultipleBranches1(t *testing.T) {
 	test := NewTest(t, "multiple_branches")
-	got := test.Run(&ripsrc.Opts{AllBranches: true})
+
+	var got []ripsrc.BlameResult
+	test.Run(&ripsrc.Opts{AllBranches: true}, func(rip *ripsrc.Ripsrc) {
+		var err error
+		got, err = rip.CodeSlice(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	if len(got) != 3 {
 		t.Fatal("expecting changes for 3 commits")
@@ -28,7 +37,15 @@ func TestMultipleBranches1(t *testing.T) {
 
 func TestMultipleBranchesDisabled(t *testing.T) {
 	test := NewTest(t, "multiple_branches_disabled")
-	got := test.Run(nil)
+
+	var got []ripsrc.BlameResult
+	test.Run(nil, func(rip *ripsrc.Ripsrc) {
+		var err error
+		got, err = rip.CodeSlice(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	if len(got) != 1 {
 		t.Fatalf("expecting changes for 1 commits, got\n%#+v", got)

--- a/ripsrc/history3/incblame/apply_merge2.go
+++ b/ripsrc/history3/incblame/apply_merge2.go
@@ -47,7 +47,10 @@ func ApplyMerge(parents []Blame, diffs []Diff, commit string, fileForDebug strin
 			line := cand[j].Lines[i]
 			// if commit is not the merge commit that means the line appeared from that parent use it in res, in case multiple sources, first will be used
 			if line.Commit != commit {
-				res.Lines[i].Commit = line.Commit
+				// create a copy to avoid mutating original, which leads to race in tests
+				lc := *res.Lines[i]
+				lc.Commit = line.Commit
+				res.Lines[i] = &lc
 				break
 			}
 		}


### PR DESCRIPTION
This fixes a bug where commits without any files were not returned by Code call.
This is required to correctly get last processed commit.

When using old Code method if the last commit is a merge with no file changes,
it would be ignored and incremental run would fail with an error.

Also fixes a data race.