### PR TITLE
Add SHA to ripsrc.BlameLine

### DIFF
--- a/e2etests/code/base.go
+++ b/e2etests/code/base.go
@@ -49,52 +49,52 @@ func assertResult(t *testing.T, want, got []ripsrc.BlameResult) {
 }
 
 // needed because BlameResult has private fields
-func assertBlame(t *testing.T, b1, b2 ripsrc.BlameResult) bool {
-	if !assertCommitEqual(t, b1.Commit, b2.Commit) {
-		t.Errorf("blame commit does not match, wanted\n%#+v\ngot\n%#+v", b1.Commit, b2.Commit)
+func assertBlame(t *testing.T, want, got ripsrc.BlameResult) bool {
+	if !assertCommitEqual(t, want.Commit, got.Commit) {
+		t.Errorf("blame commit does not match, wanted\n%#+v\ngot\n%#+v", want.Commit, got.Commit)
 		return false
 	}
-	if b1.Language != b2.Language {
+	if want.Language != got.Language {
 		return false
 	}
-	if b1.Filename != b2.Filename {
+	if want.Filename != got.Filename {
 		return false
 	}
-	if !blameLinesEqual(t, b1.Lines, b2.Lines) {
+	if !blameLinesEqual(t, want.Lines, got.Lines) {
 		t.Error("blame lines do not match, got")
-		for _, l := range b2.Lines {
+		for _, l := range got.Lines {
 			t.Logf("%+v", l)
 		}
 		return false
 	}
-	if b1.Size != b2.Size {
+	if want.Size != got.Size {
 		return false
 	}
-	if b1.Loc != b2.Loc {
+	if want.Loc != got.Loc {
 		return false
 	}
-	if b1.Sloc != b2.Sloc {
+	if want.Sloc != got.Sloc {
 		return false
 	}
-	if b1.Comments != b2.Comments {
+	if want.Comments != got.Comments {
 		return false
 	}
-	if b1.Blanks != b2.Blanks {
+	if want.Blanks != got.Blanks {
 		return false
 	}
-	if b1.Complexity != b2.Complexity {
+	if want.Complexity != got.Complexity {
 		return false
 	}
-	if b1.WeightedComplexity != b2.WeightedComplexity {
+	if want.WeightedComplexity != got.WeightedComplexity {
 		return false
 	}
-	if b1.Skipped != b2.Skipped {
+	if want.Skipped != got.Skipped {
 		return false
 	}
-	if b1.License != b2.License {
+	if want.License != got.License {
 		return false
 	}
-	if b1.Status != b2.Status {
+	if want.Status != got.Status {
 		return false
 	}
 	return true
@@ -133,6 +133,11 @@ func blameLineEqual(t *testing.T, l1, l2 *ripsrc.BlameLine) bool {
 	}
 	if l1.Blank != l2.Blank {
 		return false
+	}
+	if l1.SHA != "" {
+		if l1.SHA != l2.SHA {
+			return false
+		}
 	}
 	return true
 }
@@ -210,14 +215,16 @@ func parseGitDate(s string) time.Time {
 	return r
 }
 
-func line(name string, email string, date time.Time, comment, code, blank bool) *ripsrc.BlameLine {
+func line(name string, email string, date time.Time, comment, code, blank bool, sha string) *ripsrc.BlameLine {
 	return &ripsrc.BlameLine{
 		Name:    name,
 		Email:   email,
 		Date:    date,
 		Comment: comment,
 		Code:    code,
-		Blank:   blank}
+		Blank:   blank,
+		SHA:     sha,
+	}
 }
 
 func filep(f ripsrc.CommitFile) *ripsrc.CommitFile {

--- a/e2etests/code/basic_test.go
+++ b/e2etests/code/basic_test.go
@@ -69,8 +69,10 @@ func TestBasic(t *testing.T) {
 		Deletions: 3,
 	}
 
+	c1sha := "b4dadc54e312e976694161c2ac59ab76feb0c40d"
+
 	commit1 := ripsrc.Commit{
-		SHA:            "b4dadc54e312e976694161c2ac59ab76feb0c40d",
+		SHA:            c1sha,
 		AuthorName:     u1n,
 		AuthorEmail:    u1e,
 		CommitterName:  u1n,
@@ -86,8 +88,10 @@ func TestBasic(t *testing.T) {
 		Ordinal: 1,
 	}
 
+	c2sha := "69ba50fff990c169f80de96674919033a0a9b66d"
+
 	commit2 := ripsrc.Commit{
-		SHA:            "69ba50fff990c169f80de96674919033a0a9b66d",
+		SHA:            c2sha,
 		AuthorName:     u2n,
 		AuthorEmail:    u2e,
 		CommitterName:  u2n,
@@ -118,14 +122,14 @@ func TestBasic(t *testing.T) {
 				   	cmd.Execute()
 				   }
 				*/
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
+				line(u1n, u1e, c1d, false, true, false, c1sha),
+				line(u1n, u1e, c1d, false, false, true, c1sha),
+				line(u1n, u1e, c1d, false, true, false, c1sha),
+				line(u1n, u1e, c1d, false, false, true, c1sha),
+				line(u1n, u1e, c1d, false, true, false, c1sha),
+				line(u1n, u1e, c1d, false, true, false, c1sha),
+				line(u1n, u1e, c1d, false, true, false, c1sha),
+				line(u1n, u1e, c1d, false, false, true, c1sha),
 			},
 			Size:               84,
 			Loc:                8,
@@ -150,12 +154,12 @@ func TestBasic(t *testing.T) {
 					  // do nothing
 					}
 				*/
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u2n, u2e, c2d, true, false, false),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
+				line(u1n, u1e, c1d, false, true, false, c1sha),
+				line(u1n, u1e, c1d, false, false, true, c1sha),
+				line(u1n, u1e, c1d, false, true, false, c1sha),
+				line(u2n, u2e, c2d, true, false, false, c2sha),
+				line(u1n, u1e, c1d, false, true, false, c1sha),
+				line(u1n, u1e, c1d, false, false, true, c1sha),
 			},
 			Size:               47,
 			Loc:                6,
@@ -184,6 +188,6 @@ func TestBasic(t *testing.T) {
 		t.Fatal("invalid files len")
 	}
 
-	assertBlame(t, byCommit[0].Files[0], want[0])
+	assertBlame(t, want[0], byCommit[0].Files[0])
 
 }

--- a/e2etests/code/deleted_files_test.go
+++ b/e2etests/code/deleted_files_test.go
@@ -78,10 +78,10 @@ func TestDeletedFiles(t *testing.T) {
 				   func main() {
 				   }
 				*/
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, true, false),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c1d, false, false, true, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
 			},
 			Size:               29,
 			Loc:                4,

--- a/e2etests/code/editing_former_bin_file_test.go
+++ b/e2etests/code/editing_former_bin_file_test.go
@@ -117,10 +117,10 @@ func TestEditingFormerBinFile(t *testing.T) {
 					func main(){
 					}
 				*/
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, true, false),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c1d, false, false, true, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
 			},
 			Size:               29,
 			Loc:                4,

--- a/e2etests/code/merge_basic_test.go
+++ b/e2etests/code/merge_basic_test.go
@@ -116,10 +116,10 @@ func TestMergeBasic(t *testing.T) {
 					func main(){
 					}
 				*/
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, true, false),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c1d, false, false, true, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
 			},
 			Size:               29,
 			Loc:                4,
@@ -144,11 +144,11 @@ func TestMergeBasic(t *testing.T) {
 					// A
 					}
 				*/
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c2d, true, false, false),
-				line(u1n, u1e, c1d, false, true, false),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c1d, false, false, true, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c2d, true, false, false, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
 			},
 			Size:               34,
 			Loc:                5,
@@ -173,11 +173,11 @@ func TestMergeBasic(t *testing.T) {
 					// M
 					}
 				*/
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c3d, true, false, false),
-				line(u1n, u1e, c1d, false, true, false),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c1d, false, false, true, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c3d, true, false, false, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
 			},
 			Size:               34,
 			Loc:                5,
@@ -203,12 +203,12 @@ func TestMergeBasic(t *testing.T) {
 					// M
 					}
 				*/
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c1d, false, false, true),
-				line(u1n, u1e, c1d, false, true, false),
-				line(u1n, u1e, c3d, true, false, false),
-				line(u1n, u1e, c2d, true, false, false),
-				line(u1n, u1e, c1d, false, true, false),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c1d, false, false, true, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
+				line(u1n, u1e, c3d, true, false, false, ""),
+				line(u1n, u1e, c2d, true, false, false, ""),
+				line(u1n, u1e, c1d, false, true, false, ""),
 			},
 			Size:               39,
 			Loc:                6,

--- a/ripsrc/code.go
+++ b/ripsrc/code.go
@@ -41,6 +41,7 @@ type BlameLine struct {
 	Comment bool
 	Code    bool
 	Blank   bool
+	SHA     string
 }
 
 // License holds details about detected license

--- a/ripsrc/code_info.go
+++ b/ripsrc/code_info.go
@@ -126,6 +126,7 @@ func (s *Ripsrc) codeInfoFile(filePath string, bl *incblame.Blame, fileBytes []b
 		line2.Email = meta.AuthorEmail
 		line2.Date = meta.Date
 		line2.line = line.Line
+		line2.SHA = line.Commit
 		lines = append(lines, line2)
 	}
 


### PR DESCRIPTION
It was already set on internal line object, but not accessible through public interface. Added a test case for this.