### PR TITLE
APP-1751 Additional git log filtering in incremental runs

### DIFF
--- a/ripsrc/commit_info.go
+++ b/ripsrc/commit_info.go
@@ -10,6 +10,7 @@ func (s *Ripsrc) getCommitInfo(ctx context.Context) error {
 	copts := commitmeta.Opts{}
 	copts.CommitFromIncl = s.opts.CommitFromIncl
 	copts.AllBranches = s.opts.AllBranches
+	copts.Logger = s.opts.Logger
 	cm := commitmeta.New(s.opts.RepoDir, copts)
 	res, err := cm.RunMap()
 	if err != nil {

--- a/ripsrc/commitmeta/commitmeta.go
+++ b/ripsrc/commitmeta/commitmeta.go
@@ -214,10 +214,9 @@ func (s *Processor) gitLog() (io.ReadCloser, error) {
 		args = append(args, "--all")
 	}
 
-	//panic("todo")
-	//if s.opts.CommitFromIncl != "" {
-	//	args = append(args, s.opts.CommitFromIncl+"^..HEAD")
-	//}
+	if s.opts.CommitFromIncl != "" {
+		args = append(args, s.opts.CommitFromIncl+"^..HEAD")
+	}
 
 	return gitexec.ExecPiped(context.Background(), s.gitCommand, s.repoDir, args)
 }

--- a/ripsrc/commitmeta/commitmeta.go
+++ b/ripsrc/commitmeta/commitmeta.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pinpt/ripsrc/ripsrc/pkg/logger"
+
 	"github.com/pinpt/ripsrc/ripsrc/gitexec"
 )
 
@@ -22,6 +24,9 @@ type Opts struct {
 
 	// AllBranches set to true to process all branches. If false, processes commits reachable from HEAD only.
 	AllBranches bool
+
+	// Logger object for info and debug.
+	Logger logger.Logger
 }
 
 type Processor struct {
@@ -147,8 +152,28 @@ func (s *Processor) Run(res chan Commit) error {
 	parser.filejobs = fjChan
 
 	scanner := bufio.NewScanner(r)
+	skipping := false
+
+	var startSkip time.Time
+	if s.opts.CommitFromIncl != "" {
+		s.opts.Logger.Debug("Starting skipping git log (without patches)")
+		skipping = true
+		startSkip = time.Now()
+	}
 	for scanner.Scan() {
-		ok, err := parser.parse(scanner.Text())
+		var data string
+		if skipping {
+			b := scanner.Bytes()
+			wantPre := string(commitPrefix) + s.opts.CommitFromIncl
+			if !bytes.HasPrefix(b, []byte(wantPre)) {
+				continue
+			}
+			data = string(b)
+			s.opts.Logger.Debug("Finished skipping git log (without patches)", "dur", time.Since(startSkip))
+		} else {
+			data = scanner.Text()
+		}
+		ok, err := parser.parse(data)
 		if err != nil {
 			return fmt.Errorf("error processing commit from %v. %v", s.repoDir, err)
 		}
@@ -189,9 +214,10 @@ func (s *Processor) gitLog() (io.ReadCloser, error) {
 		args = append(args, "--all")
 	}
 
-	if s.opts.CommitFromIncl != "" {
-		args = append(args, s.opts.CommitFromIncl+"^..HEAD")
-	}
+	//panic("todo")
+	//if s.opts.CommitFromIncl != "" {
+	//	args = append(args, s.opts.CommitFromIncl+"^..HEAD")
+	//}
 
 	return gitexec.ExecPiped(context.Background(), s.gitCommand, s.repoDir, args)
 }

--- a/ripsrc/history3/process/process.go
+++ b/ripsrc/history3/process/process.go
@@ -778,9 +778,9 @@ func (s *Process) gitLogPatches() (io.ReadCloser, error) {
 		args = append(args, "--all")
 	}
 
-	//if s.opts.CommitFromIncl != "" {
-	//	args = append(args, s.opts.CommitFromIncl+"^..HEAD")
-	//}
+	if s.opts.CommitFromIncl != "" {
+		args = append(args, s.opts.CommitFromIncl+"^..HEAD")
+	}
 
 	ctx := context.Background()
 	//if s.opts.DisableCache {


### PR DESCRIPTION
When running incremental processing with AllBranches=true, git log was returning much older commits than expected. This PR adds additional filtering after parsing output of git log. It's not possible to only return what we want from git log when asking for data for all branches.