### PR TITLE
Revert "APP-1751 Additional git log filtering in incremental runs"

### DIFF
--- a/ripsrc/commit_info.go
+++ b/ripsrc/commit_info.go
@@ -10,7 +10,6 @@ func (s *Ripsrc) getCommitInfo(ctx context.Context) error {
 	copts := commitmeta.Opts{}
 	copts.CommitFromIncl = s.opts.CommitFromIncl
 	copts.AllBranches = s.opts.AllBranches
-	copts.Logger = s.opts.Logger
 	cm := commitmeta.New(s.opts.RepoDir, copts)
 	res, err := cm.RunMap()
 	if err != nil {

--- a/ripsrc/history3/process/process.go
+++ b/ripsrc/history3/process/process.go
@@ -160,21 +160,7 @@ func (s *Process) Run(resChan chan Result) error {
 		}
 	}()
 
-	skipping := false
-	var startSkip time.Time
-	if s.opts.CommitFromIncl != "" {
-		s.opts.Logger.Debug("Starting skipping git log (with patches)")
-		skipping = true
-		startSkip = time.Now()
-	}
 	for commit := range commits {
-		if s.opts.CommitFromIncl == commit.Hash {
-			s.opts.Logger.Debug("Finished skipping git log (with patches)", "dur", time.Since(startSkip))
-			skipping = false
-		}
-		if skipping {
-			continue
-		}
 		commit.Parents = s.graph.Parents[commit.Hash]
 		s.processCommit(resChan, commit)
 	}


### PR DESCRIPTION
Reverts pinpt/ripsrc#20

This may be buggy, there is no guarantee that the new commits will appear after last processed commit in git log. Will instead exclude old branches when using AllBranches=true.