### PR TITLE
DE-1807 add first commit id to branch

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pinpt/ripsrc/ripsrc"
 	"github.com/pinpt/ripsrc/ripsrc/cmd/cmdbranches"
 	"github.com/pinpt/ripsrc/ripsrc/cmd/cmdcode"
 	"github.com/spf13/cobra"
@@ -43,6 +44,30 @@ var branchesCmd = &cobra.Command{
 	},
 }
 
+var branchesMetaCmd = &cobra.Command{
+	Use:   "branches-meta <dir>",
+	Short: "Extracts information about branches from repos in a directory",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		opts := ripsrc.Opts{
+			RepoDir:     args[0],
+			AllBranches: true,
+		}
+		rip := ripsrc.New(opts)
+		ctx := context.TODO()
+		res := make(chan ripsrc.Branch)
+		go func() {
+			for b := range res {
+				fmt.Println("branch", b.Name, "first commit:", b.FirstCommit)
+			}
+		}()
+		err := rip.Branches(ctx, res)
+		if err != nil {
+			panic(err)
+		}
+	},
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -55,6 +80,7 @@ func Execute() {
 
 	branchesCmd.Flags().String("profile", "", "one of mem, mutex, cpu, block, trace or empty to disable")
 	rootCmd.AddCommand(branchesCmd)
+	rootCmd.AddCommand(branchesMetaCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
**Description:**
for master branch commits are out of order (which makes sense traversing a tree) but the chronological order is important, some things need first and last commit, so we added logic to determine the first commit.