### PR TITLE
In incrementals only process HEAD branch commits. This is a bug.

### DIFF
--- a/ripsrc/code.go
+++ b/ripsrc/code.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pinpt/ripsrc/ripsrc/branchmeta"
-
 	"github.com/pinpt/ripsrc/ripsrc/commitmeta"
 	"github.com/pinpt/ripsrc/ripsrc/fileinfo"
 	"github.com/pinpt/ripsrc/ripsrc/history3/process"
@@ -110,26 +108,28 @@ func (s *Ripsrc) CodeByCommit(ctx context.Context, res chan CommitCode) error {
 	var wantedBranchNames []string
 
 	if s.opts.CommitFromIncl != "" && s.opts.AllBranches {
-		allBranches, err := branchmeta.Get(ctx, branchmeta.Opts{
-			Logger:    s.opts.Logger,
-			RepoDir:   s.opts.RepoDir,
-			UseOrigin: s.opts.BranchesUseOrigin,
-		})
+		/*
+			allBranches, err := branchmeta.Get(ctx, branchmeta.Opts{
+				Logger:    s.opts.Logger,
+				RepoDir:   s.opts.RepoDir,
+				UseOrigin: s.opts.BranchesUseOrigin,
+			})
 
-		if err != nil {
-			return err
-		}
-
-		deadline := s.opts.IncrementalIgnoreBranchesOlderThan
-		if deadline.IsZero() {
-			deadline = time.Now().Add(-3 * 30 * 24 * time.Hour)
-		}
-		for _, b := range allBranches {
-			if b.CommitCommitterTime.After(deadline) {
-				wantedBranchRefs = append(wantedBranchRefs, b.Commit)
-				wantedBranchNames = append(wantedBranchNames, b.Name)
+			if err != nil {
+				return err
 			}
-		}
+
+			deadline := s.opts.IncrementalIgnoreBranchesOlderThan
+			if deadline.IsZero() {
+				deadline = time.Now().Add(-3 * 30 * 24 * time.Hour)
+			}
+			for _, b := range allBranches {
+				if b.CommitCommitterTime.After(deadline) {
+					wantedBranchRefs = append(wantedBranchRefs, b.Commit)
+					wantedBranchNames = append(wantedBranchNames, b.Name)
+				}
+			}
+		*/
 	}
 	if len(wantedBranchRefs) != 0 {
 		s.opts.Logger.Debug("processing additional branches", "branches", wantedBranchNames)

--- a/ripsrc/ripsrc.go
+++ b/ripsrc/ripsrc.go
@@ -38,9 +38,11 @@ type Opts struct {
 
 	// IncrementalIgnoreBranchesOlderThan provides a way to ignore old branches in incremental processing.
 	// Default is time.Now() - 90 * day
+	// BUG: this field is ignored, only processing HEAD branch in incrementals right now
 	IncrementalIgnoreBranchesOlderThan time.Time
 
 	// AllBranches set to true to process all branches. If false, processes HEAD only.
+	// BUG: in incrementals only processing HEAD branch
 	AllBranches bool
 
 	// BranchesUseOrigin by default ripsrc lists only local branches when using Branches method. Set this to true to use origin/ branches instead.


### PR DESCRIPTION
We had a bug in processing where we skipped all branches because
IncrementalIgnoreBranchesOlderThan check was wrong.

Unfortunately, just fixing that doesn't work in certain conditions
this leads to panic. Keep it disabled for now.